### PR TITLE
feat: add location preparation helper

### DIFF
--- a/src/use_cases/forecast_use_case.py
+++ b/src/use_cases/forecast_use_case.py
@@ -1,11 +1,28 @@
 from argparse import Namespace
 from logging import Logger
+import os
 import sys
 
 from src.analysis.forecast_area import RainGridForecaster
+from src.config.config import CACHE_DIR
 from src.utils.utils_logger import get_logger
 
 logger: Logger = get_logger()
+
+
+def save_forecast_grid_to_cache(lat: float, lon: float) -> None:
+    """Save the 24h forecast grid for the location to the cache directory."""
+    raise NotImplementedError
+
+
+def save_street_depths_to_cache(lat: float, lon: float) -> None:
+    """Save detected street depths for the location to the cache directory."""
+    raise NotImplementedError
+
+
+def build_kml_for_location(lat: float, lon: float) -> None:
+    """Build a KML overlay for the location and store it in the cache."""
+    raise NotImplementedError
 
 
 def run_forecast_use_case(args: Namespace) -> None:
@@ -23,3 +40,20 @@ def run_forecast_use_case(args: Namespace) -> None:
     forecaster = RainGridForecaster(center_lat=lat, center_lon=lon)
     forecaster.save_full_rain_forecast_grid()
     logger.info("✅ Vorhersage erfolgreich gespeichert.")
+
+
+def prepare_location_if_needed(lat: float, lon: float) -> None:
+    """Ensure forecast and KML data for the location exist in the cache."""
+    cache_dir = os.path.join(CACHE_DIR, f"lat{lat}_lon{lon}")
+    forecast_path = os.path.join(cache_dir, "forecast_24h.csv")
+    kml_path = os.path.join(cache_dir, "flutkarte.kml")
+
+    if os.path.isfile(forecast_path) and os.path.isfile(kml_path):
+        logger.info("✅ Daten bereits vorhanden")
+        return
+
+    logger.info("🔄 Erzeuge neue Standortdaten …")
+    os.makedirs(cache_dir, exist_ok=True)
+    save_forecast_grid_to_cache(lat, lon)
+    save_street_depths_to_cache(lat, lon)
+    build_kml_for_location(lat, lon)

--- a/tests/use_cases/test_forecast_use_case.py
+++ b/tests/use_cases/test_forecast_use_case.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from src.use_cases.forecast_use_case import run_forecast_use_case
+from src.use_cases import forecast_use_case
 
 
 @patch("src.use_cases.forecast_use_case.RainGridForecaster")
@@ -11,7 +11,7 @@ def test_forecast_use_case_calls_forecaster(mock_forecaster):
     args = Namespace(lat=49.45, lon=8.18)
     instance = mock_forecaster.return_value
 
-    run_forecast_use_case(args)
+    forecast_use_case.run_forecast_use_case(args)
 
     mock_forecaster.assert_called_once_with(center_lat=49.45, center_lon=8.18)
     instance.save_full_rain_forecast_grid.assert_called_once_with()
@@ -20,4 +20,48 @@ def test_forecast_use_case_calls_forecaster(mock_forecaster):
 def test_forecast_use_case_missing_coordinates():
     args = Namespace(lat=None, lon=None)
     with pytest.raises(SystemExit):
-        run_forecast_use_case(args)
+        forecast_use_case.run_forecast_use_case(args)
+
+
+def test_prepare_location_if_needed_existing_cache(tmp_path):
+    forecast_use_case.CACHE_DIR = str(tmp_path)
+    lat, lon = 49.45, 8.18
+    cache_dir = tmp_path / f"lat{lat}_lon{lon}"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "forecast_24h.csv").write_text("data")
+    (cache_dir / "flutkarte.kml").write_text("data")
+
+    with patch(
+        "src.use_cases.forecast_use_case.save_forecast_grid_to_cache"
+    ) as mock_forecast, patch(
+        "src.use_cases.forecast_use_case.save_street_depths_to_cache"
+    ) as mock_depths, patch(
+        "src.use_cases.forecast_use_case.build_kml_for_location"
+    ) as mock_kml:
+        forecast_use_case.prepare_location_if_needed(lat, lon)
+
+    mock_forecast.assert_not_called()
+    mock_depths.assert_not_called()
+    mock_kml.assert_not_called()
+
+
+def test_prepare_location_if_needed_generates_when_missing(tmp_path):
+    forecast_use_case.CACHE_DIR = str(tmp_path)
+    lat, lon = 50.0, 8.2
+    cache_dir = tmp_path / f"lat{lat}_lon{lon}"
+    cache_dir.mkdir(parents=True)
+    # Only one file exists
+    (cache_dir / "forecast_24h.csv").write_text("data")
+
+    with patch(
+        "src.use_cases.forecast_use_case.save_forecast_grid_to_cache"
+    ) as mock_forecast, patch(
+        "src.use_cases.forecast_use_case.save_street_depths_to_cache"
+    ) as mock_depths, patch(
+        "src.use_cases.forecast_use_case.build_kml_for_location"
+    ) as mock_kml:
+        forecast_use_case.prepare_location_if_needed(lat, lon)
+
+    mock_forecast.assert_called_once_with(lat, lon)
+    mock_depths.assert_called_once_with(lat, lon)
+    mock_kml.assert_called_once_with(lat, lon)


### PR DESCRIPTION
## Summary
- ensure forecast and KML data for a location are prepared when missing
- add placeholder cache-generation helpers and supporting tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f5eb577c832e870c9dd2f3a435b8